### PR TITLE
Add Oura for as a smart ring wear vendor

### DIFF
--- a/participation_nb.py
+++ b/participation_nb.py
@@ -6,6 +6,7 @@ app = marimo.App(width="medium")
 
 @app.cell
 def _():
+
     import marimo as mo
     return (mo,)
 
@@ -15,7 +16,7 @@ def _():
     from sensorfabric.mdh import MDH
     import pandas as pd
     import os
-    return MDH, os, pd
+    return MDH, pd
 
 
 @app.cell
@@ -25,7 +26,7 @@ def _(MDH):
 
 
 @app.cell
-def _(mdh, os):
+def _(mdh):
     segmentID = os.getenv('MDH_SEGMENT_ID') # segment ID of enrolled participants
     all_participants_data = mdh.getAllParticipants({'segmentID': segmentID})
     return (all_participants_data,)
@@ -40,6 +41,63 @@ def _():
 @app.cell
 def _():
     # mo.vstack([all_participants_table, all_participants_table.value])
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+    # Heatmap Explanation
+
+    ## Stages
+
+    We show four stages of participation:
+
+    - Prenatal Weeks 9 - 19
+    - Prenatal Weeks 20 - 30
+    - Prenatal Weeks 31 - 40
+    - Postpartum Weeks 1 - 6 (corresponds to gestational weeks 41 - 46)
+
+    Each stage includes two heatmaps:
+
+    - Counts heatmap - the number of completed days per week.
+    - Percentage heatmap - weekly completion percentages, plus Self-Report Average, Biometrics Average, and the weekly compensation calculation.
+
+    ## Activities shown in the heatmaps
+
+    - Daily symptom check-ins - up to 7 per week.
+    - Daily 6 questions - up to 7 per week.
+    - Weekly/bimonthly questionnaire - up to 1 per week.
+    - Ultrahuman smart ring wear - a day counts as 1 if daily wear ≥ 75%; up to 7 per week.
+    - Oura smart ring wear - a day counts as 1 if daily wear ≥ 75%; up to 7 per week.
+    - Twice-weekly weight measurements - up to 2 per week.
+    - Twice-weekly blood pressure measurements - up to 2 per week.
+
+    *The counts heatmap shows these raw weekly counts.*
+    *The percentage heatmap converts each row to a % of the weekly maximum (e.g., 5/7 days == ~71.4%).*
+
+    ## Averages in the percentage heatmap
+
+    Self-Report Average includes:
+
+    - Daily symptom check-ins
+    - Daily 6 questions
+    - Weekly/bimonthly questionnaire
+
+    Biometrics Average includes:
+
+    - Smart ring wear (participants wear either Ultrahuman or Oura)
+    - Twice-weekly weight measurements
+    - Twice-weekly blood pressure measurements
+
+    Weekly compensation logic
+
+    - $3 for Self-Report activities if the Self-Report Average ≥ 70%
+    - $4 for Biometric activities if the Biometrics Average ≥ 70%
+    - Weekly total = sum of the two amounts (i.e., $0, $3, $4, or $7).
+    """
+    )
     return
 
 
@@ -64,7 +122,14 @@ def _(dropdown, mdh):
 @app.cell
 def _(participant):
     participant_email = (participant['customFields']['uh_email'] or participant['accountEmail'])
-    return (participant_email,)
+    ring_vendor = participant['customFields']['ring_vendor']
+    return participant_email, ring_vendor
+
+
+@app.cell
+def _(mo, ring_vendor):
+    mo.md(f"""Ring Vendor: {ring_vendor}""")
+    return
 
 
 @app.cell
@@ -79,9 +144,10 @@ def _(
     first_w1_day,
     participant_email,
     participantidentifier,
+    ring_vendor,
     show_heatmap_for_stage,
 ):
-    stage1_fig_1, stage1_fig_2 = show_heatmap_for_stage(participant_email, participantidentifier, 9, 19, "Prenatal Weeks 9-19 — Weekly Compliance Heatmap", first_w1_day)
+    stage1_fig_1, stage1_fig_2 = show_heatmap_for_stage(participant_email, participantidentifier, 9, 19, "Prenatal Weeks 9-19 — Weekly Compliance Heatmap", first_w1_day, ring_vendor)
     return stage1_fig_1, stage1_fig_2
 
 
@@ -102,9 +168,10 @@ def _(
     first_w1_day,
     participant_email,
     participantidentifier,
+    ring_vendor,
     show_heatmap_for_stage,
 ):
-    stage2_fig_1, stage2_fig_2 = show_heatmap_for_stage(participant_email, participantidentifier, 20, 30, "Prenatal Weeks 20-30 — Weekly Compliance Heatmap", first_w1_day)
+    stage2_fig_1, stage2_fig_2 = show_heatmap_for_stage(participant_email, participantidentifier, 20, 30, "Prenatal Weeks 20-30 — Weekly Compliance Heatmap", first_w1_day, ring_vendor)
     return stage2_fig_1, stage2_fig_2
 
 
@@ -125,9 +192,10 @@ def _(
     first_w1_day,
     participant_email,
     participantidentifier,
+    ring_vendor,
     show_heatmap_for_stage,
 ):
-    stage3_fig_1, stage3_fig_2 = show_heatmap_for_stage(participant_email, participantidentifier, 31, 40, "Prenatal Weeks 31-40 — Weekly Compliance Heatmap", first_w1_day)
+    stage3_fig_1, stage3_fig_2 = show_heatmap_for_stage(participant_email, participantidentifier, 31, 40, "Prenatal Weeks 31-40 — Weekly Compliance Heatmap", first_w1_day, ring_vendor)
     return stage3_fig_1, stage3_fig_2
 
 
@@ -148,9 +216,10 @@ def _(
     first_w1_day,
     participant_email,
     participantidentifier,
+    ring_vendor,
     show_heatmap_for_stage,
 ):
-    stage4_fig_1, stage4_fig_2 = show_heatmap_for_stage(participant_email, participantidentifier, 41, 46, "Postpartum Weeks 1-6 — Weekly Compliance Heatmap", first_w1_day)
+    stage4_fig_1, stage4_fig_2 = show_heatmap_for_stage(participant_email, participantidentifier, 41, 46, "Postpartum Weeks 1-6 — Weekly Compliance Heatmap", first_w1_day, ring_vendor)
     return stage4_fig_1, stage4_fig_2
 
 
@@ -163,11 +232,6 @@ def _(mo, stage4_fig_1):
 @app.cell
 def _(mo, stage4_fig_2):
     mo.mpl.interactive(stage4_fig_2)
-    return
-
-
-@app.cell
-def _():
     return
 
 


### PR DESCRIPTION
- Participants might use either Ultrahuman or Oura; this PR takes into consideration the `ring_vendor` attribute from MDH and calculates compliance data accordingly.
- Additionally, explanations for compliance calculations are included, along with weekly compensation and total stage payment, in heatmaps as well.